### PR TITLE
Centralize JSON result handling with ToolResult integration

### DIFF
--- a/FlowChat/Helpers/ToolResult.cs
+++ b/FlowChat/Helpers/ToolResult.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FlowChat.Helpers;
+
+public static class ToolResult
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>
+    /// Returns a JSON-formatted tool result with <c>status: "success"</c>.
+    /// </summary>
+    /// <param name="result">
+    /// The result payload. Strings are serialized as a JSON string value;
+    /// objects are serialized as a nested JSON object.
+    /// </param>
+    /// <returns>
+    /// A JSON string of the form <c>{"status":"success","result":...}</c>.
+    /// </returns>
+    public static string Success(object result) =>
+        Serialize("success", result);
+
+    /// <summary>
+    /// Returns a JSON-formatted tool result with <c>status: "failure"</c>.
+    /// </summary>
+    /// <param name="result">
+    /// A description of what went wrong. Strings are serialized as a JSON string value;
+    /// objects are serialized as a nested JSON object.
+    /// </param>
+    /// <returns>
+    /// A JSON string of the form <c>{"status":"failure","result":...}</c>.
+    /// </returns>
+    public static string Failure(object result) =>
+        Serialize("failure", result);
+
+    private static string Serialize(string status, object result) =>
+        JsonSerializer.Serialize(new { status, result }, JsonOptions);
+}

--- a/FlowChat/Tools/MemoryManager.cs
+++ b/FlowChat/Tools/MemoryManager.cs
@@ -2,6 +2,7 @@
 using Anthropic.SDK.Common;
 using Discord.WebSocket;
 using FlowChat.Enums;
+using FlowChat.Helpers;
 using FlowChat.Models;
 
 namespace FlowChat.Tools;
@@ -12,8 +13,8 @@ public class MemoryManager
     private readonly ISocketMessageChannel _channel;
     private readonly List<Memory> _memories;
     private bool _initialized = false;
-    
-    private readonly JsonSerializerOptions _jsonOptions = new()
+
+    private static readonly JsonSerializerOptions FileJsonOptions = new()
     {
         WriteIndented = true,
         Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
@@ -74,7 +75,7 @@ public class MemoryManager
         _memories.Add(memory);
         await SaveMemories();
     
-        return $"Memory stored with {memory.Keywords.Count} keywords extracted.";
+        return ToolResult.Success($"Memory stored with {memory.Keywords.Count} keywords extracted.");
     }
     
     [Function(
@@ -106,10 +107,10 @@ public class MemoryManager
 
         if (topMemories.Count == 0)
         {
-            return "No relevant memories found.";
+            return ToolResult.Success("No relevant memories found.");
         }
 
-        return JsonSerializer.Serialize(topMemories, _jsonOptions);
+        return ToolResult.Success(topMemories);
     }
     
     private int CalculateRelevanceScore(Memory memory, string[] keywords, MemoryType? memoryType = null)
@@ -200,7 +201,7 @@ public class MemoryManager
         if (privateMemories.Count != 0)
         {
             Directory.CreateDirectory("./memories/private/");
-            var privateJson = JsonSerializer.Serialize(privateMemories, _jsonOptions);
+            var privateJson = JsonSerializer.Serialize(privateMemories, FileJsonOptions);
             await File.WriteAllTextAsync(PrivateFilePath, privateJson);
         }
         
@@ -219,7 +220,7 @@ public class MemoryManager
             existingPublic.AddRange(publicMemories);
         
             Directory.CreateDirectory("./memories/public/");
-            var publicJson = JsonSerializer.Serialize(existingPublic, _jsonOptions);
+            var publicJson = JsonSerializer.Serialize(existingPublic, FileJsonOptions);
             await File.WriteAllTextAsync(PublicFilePath, publicJson);
         }
     }

--- a/FlowChat/Tools/VoiceChannelTools.cs
+++ b/FlowChat/Tools/VoiceChannelTools.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 using Anthropic.SDK.Common;
 using Discord;
 using Discord.WebSocket;
+using FlowChat.Helpers;
 using FlowChat.Services.Implementations;
 using Microsoft.Extensions.Logging;
 
@@ -14,12 +14,6 @@ public class VoiceChannelTools
     private readonly GuildContextManager _contextManager;
     private readonly ILogger<VoiceChannelTools> _logger;
     
-    private readonly JsonSerializerOptions _jsonOptions = new()
-    {
-        WriteIndented = true,
-        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-    };
-
     public VoiceChannelTools(SocketMessage message, GuildContextManager contextManager,
         ILogger<VoiceChannelTools> logger)
     {
@@ -77,17 +71,17 @@ public class VoiceChannelTools
         {
             if (!TryGetVoiceService(out VoiceService? voiceService, out var errorMessage))
             {
-                return errorMessage;
+                return ToolResult.Failure(errorMessage);
             }
 
             if (voiceService.IsConnected)
             {
-                return $"Already connected to \"{voiceService.ConnectedChannel}\"";
+                return ToolResult.Failure($"Already connected to \"{voiceService.ConnectedChannel}\"");
             }
             
             if (_message.Author is not IGuildUser guildUser || guildUser.VoiceChannel is null)
             {
-                return "You must be in a voice channel for me to join";
+                return ToolResult.Failure("You must be in a voice channel for me to join");
             }
 
             _logger.LogInformation(
@@ -97,12 +91,12 @@ public class VoiceChannelTools
                 guildUser.Guild.Name);
 
             await voiceService.ConnectAsync(guildUser.VoiceChannel.Id);
-            return $"Joined voice channel: {voiceService.ConnectedChannel}";
+            return ToolResult.Success($"Joined voice channel: {voiceService.ConnectedChannel}");
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error joining voice channel");
-            return $"Error connecting to channel: {e.Message}";
+            return ToolResult.Failure($"Error connecting to channel: {e.Message}");
         }
     }
 
@@ -114,19 +108,19 @@ public class VoiceChannelTools
         {
             if (!TryGetVoiceService(out VoiceService? voiceService, out var errorMessage, requireConnected: true))
             {
-                return errorMessage;
+                return ToolResult.Failure(errorMessage);
             }
 
             var voiceChannelName = voiceService.ConnectedChannel;
             await voiceService.DisconnectAsync();
 
             _logger.LogInformation("Left voice channel {Channel}", voiceChannelName);
-            return $"Left voice channel: {voiceChannelName}";
+            return ToolResult.Success($"Left voice channel: {voiceChannelName}");
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error leaving voice channel");
-            return $"Error disconnecting from channel: {e.Message}";
+            return ToolResult.Failure($"Error disconnecting from channel: {e.Message}");
         }
     }
 
@@ -139,23 +133,23 @@ public class VoiceChannelTools
         {
             if (!TryGetVoiceService(out VoiceService? voiceService, out var errorMessage, requireConnected: true))
             {
-                return errorMessage;
+                return ToolResult.Failure(errorMessage);
             }
 
             voiceService.SetMusicInteractionChannel(_message.Channel as SocketTextChannel);
             var result = await voiceService.SearchAndQueueMusicAsync(searchQuery);
-            
-            _logger.LogInformation("Queued music: {Title} at position {Position}", 
+
+            _logger.LogInformation("Queued music: {Title} at position {Position}",
                 result.Title, result.QueuePosition);
 
             return result.QueuePosition == 0
-                ? $"Now playing: {result.Title}"
-                : $"Added to queue (position {result.QueuePosition}): {result.Title}";
+                ? ToolResult.Success($"Now playing: {result.Title}")
+                : ToolResult.Success($"Added to queue (position {result.QueuePosition}): {result.Title}");
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error playing music");
-            return $"Error playing music: {e.Message}";
+            return ToolResult.Failure($"Error playing music: {e.Message}");
         }
     }
 
@@ -167,7 +161,7 @@ public class VoiceChannelTools
         {
             if (!TryGetVoiceService(out VoiceService? voiceService, out var errorMessage, requireConnected: true))
             {
-                return Task.FromResult(errorMessage);
+                return Task.FromResult(ToolResult.Failure(errorMessage));
             }
 
             voiceService.SetMusicInteractionChannel(_message.Channel as SocketTextChannel);
@@ -175,16 +169,16 @@ public class VoiceChannelTools
 
             if (!voiceService.SkipCurrentSong())
             {
-                return Task.FromResult("No music to skip.");
+                return Task.FromResult(ToolResult.Failure("No music to skip."));
             }
 
             _logger.LogInformation("Skipped track: {Track}", currentTrack);
-            return Task.FromResult($"Skipped {currentTrack}");
+            return Task.FromResult(ToolResult.Success($"Skipped {currentTrack}"));
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error skipping music");
-            return Task.FromResult($"Error skipping music: {e.Message}");
+            return Task.FromResult(ToolResult.Failure($"Error skipping music: {e.Message}"));
         }
     }
 
@@ -196,28 +190,26 @@ public class VoiceChannelTools
         {
             if (!TryGetVoiceService(out VoiceService? voiceService, out var errorMessage, requireConnected: true))
             {
-                return Task.FromResult(errorMessage);
+                return Task.FromResult(ToolResult.Failure(errorMessage));
             }
 
             var currentTrack = voiceService.GetCurrentTrack();
             var queuedTracks = voiceService.GetQueuedTracks();
             var currentProgress = voiceService.GetCurrentTrackProgress();
             var remainingQueueTime = voiceService.GetRemainingQueueTime();
-            
-            object responseObject = new
+
+            return Task.FromResult(ToolResult.Success(new
             {
                 CurrentTrack = currentTrack,
                 CurrentProgress = currentProgress,
                 QueuedTracks = queuedTracks,
                 TotalRemainingQueueTime = remainingQueueTime
-            };
-            
-            return Task.FromResult(JsonSerializer.Serialize(responseObject, _jsonOptions));
+            }));
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error getting queue");
-            return Task.FromResult($"Error getting queue: {e.Message}");
+            return Task.FromResult(ToolResult.Failure($"Error getting queue: {e.Message}"));
         }
     }
 
@@ -229,18 +221,18 @@ public class VoiceChannelTools
         {
             if (!TryGetVoiceService(out VoiceService? voiceService, out var errorMessage, requireConnected: true))
             {
-                return errorMessage;
+                return ToolResult.Failure(errorMessage);
             }
 
             await voiceService.PlayTextToSpeechAsync(message);
 
             _logger.LogInformation("Speaking TTS in voice channel");
-            return "Speaking...";
+            return ToolResult.Success("Speaking...");
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error speaking in voice channel");
-            return $"Error speaking in voice channel: {e.Message}";
+            return ToolResult.Failure($"Error speaking in voice channel: {e.Message}");
         }
     }
 
@@ -252,17 +244,17 @@ public class VoiceChannelTools
         {
             if (!TryGetVoiceService(out VoiceService? voiceService, out var errorMessage, requireConnected: true))
             {
-                return Task.FromResult(errorMessage);
+                return Task.FromResult(ToolResult.Failure(errorMessage));
             }
 
             volume = voiceService.SetMusicVolume(volume);
 
-            return Task.FromResult($"The volume has been set to {volume}");
+            return Task.FromResult(ToolResult.Success($"The volume has been set to {volume}"));
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error setting the volume");
-            return Task.FromResult($"Error setting the volume: {e.Message}");
+            return Task.FromResult(ToolResult.Failure($"Error setting the volume: {e.Message}"));
         }
     }
 }


### PR DESCRIPTION
This PR makes tool calls return a json object to the LLM with a standardized structure of

```json
{
    "status": "success|failure",
    "result": "string|object"
}
```